### PR TITLE
Add min/max value constraints options to SIRT implementation

### DIFF
--- a/ts_algorithms/sirt.py
+++ b/ts_algorithms/sirt.py
@@ -45,7 +45,7 @@ def sirt(A, y, num_iterations, min_constraint=None, max_constraint=None):
         A.T(y_tmp, out=x_tmp)
         x_tmp *= C
         x_cur -= x_tmp
-        if min_constraint or max_constraint:
+        if (min_constraint is not None) or (max_constraint is not None):
             x_cur.clamp_(min_constraint, max_constraint)
 
     return x_cur

--- a/ts_algorithms/sirt.py
+++ b/ts_algorithms/sirt.py
@@ -45,6 +45,7 @@ def sirt(A, y, num_iterations, min_constraint=0.0, max_constraint=None):
         A.T(y_tmp, out=x_tmp)
         x_tmp *= C
         x_cur -= x_tmp
-        x_cur.clamp_(min_constraint, max_constraint)
+        if min_constraint or max_constraint:
+            x_cur.clamp_(min_constraint, max_constraint)
 
     return x_cur

--- a/ts_algorithms/sirt.py
+++ b/ts_algorithms/sirt.py
@@ -3,7 +3,7 @@ import torch
 import math
 
 
-def sirt(A, y, num_iterations):
+def sirt(A, y, num_iterations, min_constraint=0.0, max_constraint=None):
     """Execute the SIRT algorithm
 
     If `y` is located on GPU, the entire algorithm is executed on a single GPU.
@@ -14,6 +14,10 @@ def sirt(A, y, num_iterations):
     :param A: `tomosipo.operator`
     :param y: `torch.tensor`
     :param num_iterations: `int`
+    :param min_constraint: `float`
+        Minimum value enforced at each iteration. Setting to None skips this step.
+    :param max_constraint: `float`
+        Maximum value enforced at each iteration. Setting to None skips this step.
 
     :returns:
     :rtype:
@@ -41,5 +45,6 @@ def sirt(A, y, num_iterations):
         A.T(y_tmp, out=x_tmp)
         x_tmp *= C
         x_cur -= x_tmp
+        x_cur.clamp_(min_constraint, max_constraint)
 
     return x_cur

--- a/ts_algorithms/sirt.py
+++ b/ts_algorithms/sirt.py
@@ -3,7 +3,7 @@ import torch
 import math
 
 
-def sirt(A, y, num_iterations, min_constraint=0.0, max_constraint=None):
+def sirt(A, y, num_iterations, min_constraint=None, max_constraint=None):
     """Execute the SIRT algorithm
 
     If `y` is located on GPU, the entire algorithm is executed on a single GPU.


### PR DESCRIPTION
Add min and max value constraints to enforce at each iteration of SIRT (mimicking the corresponding options in Astra). I set the default value for `min_constraint` to 0.0, because non-negativity constraint is used in most SIRT implementations I've seen. However, it can of course be set to `None` to preserve the current behavior.