### PR TITLE
Refactor FBP filter padding

### DIFF
--- a/tests/test_fbp.py
+++ b/tests/test_fbp.py
@@ -54,7 +54,6 @@ def test_fbp_filter_error_handling():
         fbp(A, y, padded=False, filter=torch.ones(y.shape[-1] + 1))
 
     # Padded
-    fbp(A, y, padded=True, filter=torch.ones(y.shape[-1]))
     fbp(A, y, padded=True, filter=torch.ones(2 * y.shape[-1]))
     with pytest.raises(ValueError):
         fbp(A, y, padded=True, filter=torch.ones(y.shape[-1] + 1))

--- a/tests/test_fdk.py
+++ b/tests/test_fdk.py
@@ -41,17 +41,7 @@ phantom64 = [
     make_box_phantom(),
 ]
 
-# Due to a different approach in padding to ASTRA during the filtering
-# of FBP, there is a difference on the edges between our
-# reconstruction and ASTRA's. Therefore, we make the detector
-# substantially larger so that padding does not matter anymore.
-pg64_astra = [
-    ts.cone(angles=96, shape=192, src_det_dist=192),
-    ts.cone(angles=96, shape=192, size=3.0, src_det_dist=3),
-    ts.cone(angles=96, shape=192, size=6.0, src_det_dist=3, src_orig_dist=3),
-]
-
-@pytest.mark.parametrize("vg, pg, x", zip(vg64, pg64_astra, phantom64))
+@pytest.mark.parametrize("vg, pg, x", zip(vg64, pg64, phantom64))
 def test_astra_compatibility(vg, pg, x):
     A = ts.operator(vg, pg)
     y = A(x)

--- a/ts_algorithms/fbp.py
+++ b/ts_algorithms/fbp.py
@@ -5,8 +5,21 @@ import numpy as np
 
 
 def ram_lak(n):
-    # Returns a ram_lak filter in filter space.
-    # Complex component equals zero.
+    """Compute Ram-Lak filter in real space
+
+    Computes a real space Ram-Lak filter optimized w.r.t. discretization bias
+    introduced if a naive ramp function is used to filter projections in
+    reciprocal space. For details, see section 3.3.3 in Kak & Staley,
+    "Principles of Computerized Tomographic Imaging", SIAM, 2001.
+
+    :param n: `int`
+        Length of the filter.
+
+    :returns:
+        Real space Ram-Lak filter of length n.
+    :rtype: `torch.tensor`
+    """
+
     filter = torch.zeros(n)
     filter[0] = 0.25
     # even indices are zero


### PR DESCRIPTION
This PR is mostly focused on reverting 9cbe3ca and 57982ab (resulting in using a Ram-Lak filter of the same with as the padded sinogram) to improve correspondence to Astra and to follow http://dx.doi.org/10.1109/tns.2014.2363776 more closely. 

Here is the simple test I used:
```python
from ts_algorithms.fbp import ram_lak, filter_sino
import numpy as np
import matplotlib.pyplot as plt


def make_box_phantom():
    x = torch.zeros((64, 64, 64))
    x[8:56, 8:56, 8:56] = 1.0
    x[24:44, 24:44, 24:44] = 0.0
    return x

x = make_box_phantom()
vg = ts.volume(shape=64)
# Use truncated projection data to exacerbate padding importance
pg = ts.cone(angles=96, shape=70, src_det_dist=192)
A = ts.operator(vg, pg)
y = A(x)

# Current implementation
rec_ts = tsa.fdk(A, y, padded=True)

# Zero-padding of the filter
h = ram_lak(y.shape[2])
h = torch.fft.fftshift(h)
h = torch.nn.functional.pad(h, (y.shape[2] // 2, y.shape[2] // 2))
h = torch.fft.ifftshift(h)
rec_zero_padding = tsa.fdk(A, y, padded=True, filter=h)

# Ram-Lak filter of the same width as the padded sinogram
h = ram_lak(2 * y.shape[2])
rec_larger_filt = tsa.fdk(A, y, padded=True, filter=h)

# Astra
rec_astra = astra_fdk(A, y)

# Reconstruction
plot_imgs(
    rec_ts=rec_ts[x.shape[0] // 2],
    rec_zero_padding=rec_zero_padding[x.shape[0] // 2],
    rec_larger_filt=rec_larger_filt[x.shape[0] // 2],
    rec_astra=rec_astra[x.shape[0] // 2]
)
# Differences to the ground truth
plot_imgs(
    rec_ts=(rec_ts - x)[x.shape[0] // 2],
    rec_zero_padding=(rec_zero_padding - x)[x.shape[0] // 2],
    rec_larger_filt=(rec_larger_filt - x)[x.shape[0] // 2],
    rec_astra=(rec_astra - x)[x.shape[0] // 2]
)
# Differences to Astra reconstruction
plot_imgs(
    rec_ts=(rec_ts - rec_astra)[x.shape[0] // 2],
    rec_zero_padding=(rec_zero_padding - rec_astra)[x.shape[0] // 2],
    rec_larger_filt=(rec_larger_filt - rec_astra)[x.shape[0] // 2]
)
# Line profiles
plt.figure()
plt.plot(rec_ts[x.shape[0] // 2, x.shape[1] // 2, :], '--', label='rec_ts')
plt.plot(rec_zero_padding[x.shape[0] // 2, x.shape[1] // 2, :], '--', label='rec_zero_padding')
plt.plot(rec_larger_filt[x.shape[0] // 2, x.shape[1] // 2, :], '--', label='rec_larger_filt')
plt.plot(rec_astra[x.shape[0] // 2, x.shape[1] // 2, :], '--', label='rec_astra')
plt.plot(x[x.shape[0] // 2, x.shape[1] // 2, :], label='phantom')
plt.legend()
``` 
![image](https://github.com/ahendriksen/ts_algorithms/assets/31259212/e4e161eb-8dd5-4993-ba18-cd45f55b83fb)
![image](https://github.com/ahendriksen/ts_algorithms/assets/31259212/82cf8e6e-10c7-4f23-8e3a-78fc104a754c)
![image](https://github.com/ahendriksen/ts_algorithms/assets/31259212/edaa2d60-3b21-4915-8391-d40474e15958)
![image](https://github.com/ahendriksen/ts_algorithms/assets/31259212/66eac19c-545f-455d-83cc-9ade700eb7b2)

As you can see, current implementation and zero-padding of the filter result in worse correspondence to both ground truth and Astra as compared to a wider filter, especially at the edges of the reconstruction. However, I realize I may be missing some rationale for doing the padding this way, so I'm curious about your comments.
