### PR TITLE
l2 Constrained TV minimization using Chambolle-Pock

### DIFF
--- a/ts_algorithms/__init__.py
+++ b/ts_algorithms/__init__.py
@@ -21,7 +21,7 @@ import tomosipo.torch_support
 
 from .sirt import sirt
 from .fbp import fbp
-from .tv_min import tv_min2d
+from .tv_min import tv_min2d, l2con_tv_min2d
 from .operators import operator_norm, ATA_max_eigenvalue
 from .fdk import fdk
 from .nag_ls import nag_ls


### PR DESCRIPTION
Adds an algorithm `l2con_tv_min2d` for solving a residual constrained TV minimization problem using Chambolle-Pock, based on the implementation of `tv_min2d`.

Both  `l2con_tv_min2d` and `tv_min2d` print the duality-gap if `progress_bar = True` is set, though the duality gap currently does not converge to zero. Perhaps due to a mismatch between (smoothed) (an)isotropic TV regularization?