### PR TITLE
Remove smoothing in TV functional

### DIFF
--- a/ts_algorithms/tv_min.py
+++ b/ts_algorithms/tv_min.py
@@ -54,8 +54,7 @@ def operator_norm_plus_grad(A, num_iter=10):
 
 
 def magnitude(z):
-    # Add a small term to avoid division by zero when computing gradients
-    return torch.sqrt(z[:, 0:1] ** 2 + z[:, 1:2] ** 2 + ts.epsilon ** 2)
+    return torch.norm(z, dim=1)
 
 
 def clip(z, lamb):


### PR DESCRIPTION
In d9741ef, the TV functional was changed to use a smoothing parameter to avoid possible division by zero if gradients are calculated. However, the makes the Chambolle-Pock algorithm not applicable. Instead of smoothing, this addresses the division problem by replacing the gradient at zero with its subgradient (zero in this case). This is also the default
behavior of `torch.norm` function.